### PR TITLE
revert authentication to sending back the auth token 

### DIFF
--- a/server/controllers/UserController.ts
+++ b/server/controllers/UserController.ts
@@ -3,7 +3,6 @@ import { matchedData, validationResult } from 'express-validator';
 import userService = require('../services/UserService');
 import mediaService = require('../services/MediaService');
 import linkService = require('../services/LinkService');
-import dayjs = require('dayjs');
 
 export const login = async (req: Request, res: Response) => {
     const { email, password } = req.body;
@@ -17,11 +16,7 @@ export const login = async (req: Request, res: Response) => {
         });
     }
 
-    res.cookie('auth', token, {
-        secure: process.env.NODE_ENV === 'production',
-        httpOnly: true,
-        expires: dayjs().add(24, 'hours').toDate(),
-    }).sendStatus(200);
+    res.status(200).json({ auth_token: token });
 };
 
 export const register = async (req: Request, res: Response) => {
@@ -34,7 +29,7 @@ export const register = async (req: Request, res: Response) => {
             });
         }
 
-        const newUser = await userService.createUser({
+        await userService.createUser({
             ...matchedData(req, {
                 locations: ['body'],
                 includeOptionals: true,
@@ -48,11 +43,9 @@ export const register = async (req: Request, res: Response) => {
             req.body.password
         );
 
-        res.cookie('auth', token, {
-            secure: process.env.NODE_ENV === 'production',
-            httpOnly: true,
-            expires: dayjs().add(24, 'hours').toDate(),
-        }).sendStatus(201);
+        res.status(201).json({
+            auth_token: token,
+        });
     } catch (err: any) {
         console.log(err);
         res.status(400).json({

--- a/server/index.ts
+++ b/server/index.ts
@@ -6,7 +6,6 @@ import userRouter from './routes/UserRouter';
 import linksRouter from './routes/LinkRouter';
 import cloudinary from 'cloudinary';
 import cors from 'cors';
-import cookieParser from 'cookie-parser';
 
 dotenv.config({ path: './config/.env' });
 
@@ -17,7 +16,6 @@ AppDataSource.initialize().catch((err) => console.log(err));
 cloudinary.v2.config();
 
 app.use(express.json());
-app.use(cookieParser());
 app.use(express.urlencoded({ extended: false }));
 app.use(
   cors({

--- a/server/middleware/Authentication.ts
+++ b/server/middleware/Authentication.ts
@@ -3,26 +3,31 @@ import { Request, Response, NextFunction } from 'express';
 import userService = require('../services/UserService');
 
 export async function authenticateUser(
-  req: Request,
-  res: Response,
-  next: NextFunction
+    req: Request,
+    res: Response,
+    next: NextFunction
 ) {
-  try {
-    const token = req.cookies.auth;
+    try {
+        const token =
+            req.headers.authorization &&
+            req.headers.authorization.split(' ')[1];
 
-    if (!token) {
-      return res.sendStatus(401);
+        if (!token) {
+            return res.sendStatus(401);
+        }
+
+        const { userId } = jwt.verify(
+            token,
+            process.env.TOKEN_SECRET!
+        ) as JwtPayload;
+
+        const user = await userService.findById(userId);
+        if (!user) {
+            return res.sendStatus(401);
+        }
+        res.locals.user = user;
+        next();
+    } catch (err) {
+        return res.sendStatus(401);
     }
-
-    const { id } = jwt.verify(token, process.env.TOKEN_SECRET!) as JwtPayload;
-
-    const user = await userService.findById(id);
-    if (!user) {
-      return res.sendStatus(401);
-    }
-    res.locals.user = user;
-    next();
-  } catch (err) {
-    return res.sendStatus(401);
-  }
 }

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -11,10 +11,8 @@
             "dependencies": {
                 "bcryptjs": "^2.4.3",
                 "cloudinary": "^1.30.0",
-                "cookie-parser": "^1.4.6",
                 "cors": "^2.8.5",
                 "datauri": "^4.1.0",
-                "dayjs": "^1.11.3",
                 "dotenv": "^16.0.1",
                 "express": "^4.18.1",
                 "express-validator": "^6.14.2",
@@ -26,7 +24,6 @@
             },
             "devDependencies": {
                 "@types/bcryptjs": "^2.4.2",
-                "@types/cookie-parser": "^1.4.3",
                 "@types/cors": "^2.8.12",
                 "@types/express": "^4.17.13",
                 "@types/jest": "^28.1.3",
@@ -1479,15 +1476,6 @@
                 "@types/node": "*"
             }
         },
-        "node_modules/@types/cookie-parser": {
-            "version": "1.4.3",
-            "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.3.tgz",
-            "integrity": "sha512-CqSKwFwefj4PzZ5n/iwad/bow2hTCh0FlNAeWLtQM3JA/NX/iYagIpWG2cf1bQKQ2c9gU2log5VUCrn7LDOs0w==",
-            "dev": true,
-            "dependencies": {
-                "@types/express": "*"
-            }
-        },
         "node_modules/@types/cors": {
             "version": "2.8.12",
             "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.12.tgz",
@@ -2843,26 +2831,6 @@
                 "node": ">= 0.6"
             }
         },
-        "node_modules/cookie-parser": {
-            "version": "1.4.6",
-            "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
-            "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
-            "dependencies": {
-                "cookie": "0.4.1",
-                "cookie-signature": "1.0.6"
-            },
-            "engines": {
-                "node": ">= 0.8.0"
-            }
-        },
-        "node_modules/cookie-parser/node_modules/cookie": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
-            "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
         "node_modules/cookie-signature": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
@@ -2872,7 +2840,6 @@
             "version": "3.6.5",
             "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
             "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==",
-            "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.",
             "hasInstallScript": true,
             "funding": {
                 "type": "opencollective",
@@ -2957,11 +2924,6 @@
                 "type": "opencollective",
                 "url": "https://opencollective.com/date-fns"
             }
-        },
-        "node_modules/dayjs": {
-            "version": "1.11.3",
-            "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.3.tgz",
-            "integrity": "sha512-xxwlswWOlGhzgQ4TKzASQkUhqERI3egRNqgV4ScR8wlANA/A9tZ7miXa44vTTKEq5l7vWoL5G57bG3zA+Kow0A=="
         },
         "node_modules/debug": {
             "version": "2.6.9",
@@ -9842,15 +9804,6 @@
                 "@types/node": "*"
             }
         },
-        "@types/cookie-parser": {
-            "version": "1.4.3",
-            "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.3.tgz",
-            "integrity": "sha512-CqSKwFwefj4PzZ5n/iwad/bow2hTCh0FlNAeWLtQM3JA/NX/iYagIpWG2cf1bQKQ2c9gU2log5VUCrn7LDOs0w==",
-            "dev": true,
-            "requires": {
-                "@types/express": "*"
-            }
-        },
         "@types/cors": {
             "version": "2.8.12",
             "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.12.tgz",
@@ -10888,22 +10841,6 @@
             "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
             "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw=="
         },
-        "cookie-parser": {
-            "version": "1.4.6",
-            "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
-            "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
-            "requires": {
-                "cookie": "0.4.1",
-                "cookie-signature": "1.0.6"
-            },
-            "dependencies": {
-                "cookie": {
-                    "version": "0.4.1",
-                    "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
-                    "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
-                }
-            }
-        },
         "cookie-signature": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
@@ -10970,11 +10907,6 @@
             "version": "2.28.0",
             "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
             "integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw=="
-        },
-        "dayjs": {
-            "version": "1.11.3",
-            "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.3.tgz",
-            "integrity": "sha512-xxwlswWOlGhzgQ4TKzASQkUhqERI3egRNqgV4ScR8wlANA/A9tZ7miXa44vTTKEq5l7vWoL5G57bG3zA+Kow0A=="
         },
         "debug": {
             "version": "2.6.9",

--- a/server/package.json
+++ b/server/package.json
@@ -18,10 +18,8 @@
     "dependencies": {
         "bcryptjs": "^2.4.3",
         "cloudinary": "^1.30.0",
-        "cookie-parser": "^1.4.6",
         "cors": "^2.8.5",
         "datauri": "^4.1.0",
-        "dayjs": "^1.11.3",
         "dotenv": "^16.0.1",
         "express": "^4.18.1",
         "express-validator": "^6.14.2",
@@ -33,7 +31,6 @@
     },
     "devDependencies": {
         "@types/bcryptjs": "^2.4.2",
-        "@types/cookie-parser": "^1.4.3",
         "@types/cors": "^2.8.12",
         "@types/express": "^4.17.13",
         "@types/jest": "^28.1.3",

--- a/server/routes/UserRouter.ts
+++ b/server/routes/UserRouter.ts
@@ -25,7 +25,7 @@ router.post(
 // LOGIN an existing user
 router.post('/login', userController.login);
 
-// UPDATE an existing user
+// UPDATE an the current user
 router.patch(
     '/',
     authenticateUser,
@@ -33,7 +33,7 @@ router.patch(
     userController.updateUserInfo
 );
 
-// DELETE an existing user
+// DELETE an the current user
 router.delete('/', authenticateUser, userController.deleteUser);
 
 // Log the current user out


### PR DESCRIPTION
Rather than setting it in a cookie.

because cookies cannot be set on other domains.

My frontend is hosted on a different domain than my backend, thus the cookies cannot be set on the frontend, and therefore no auth.

To fix this I will just return the auth token (and potentially refresh token in the future) and let the client set it in their cookies by themselves. Although this is less secure since we can't set httpOnly cookies, it is still better than local/session storage. Hopefully setting a short expiry time + a refresh token can combat this issue. Authentication is a very confusing issue. I wish there was an end-all be-all solution to all auth.