### PR TITLE
Add go to media page button

### DIFF
--- a/client/components/FloatingMediaDetails.tsx
+++ b/client/components/FloatingMediaDetails.tsx
@@ -27,7 +27,7 @@ export default function FloatingMediaDetails({
       className="fixed w-full h-full bg-black bg-opacity-90 z-10"
       onClick={() => setMediaDetails(null)}
     >
-      <div className="fixed top-0 left-2 text-white text-xl md:text-3xl mt-2 ml-2 text-center duration-300 transition-colors hover:text-red-400 cursor-pointer">
+      <div className="fixed top-0 left-2 text-white text-xl md:text-3xl mt-2 ml-2 text-center duration-300 transition-colors hover:text-red-400 cursor-pointer select-none">
         ✕
       </div>
       <div className="flex h-full left-0 right-0 top-0 bottom-0 m-auto z-20 space-x-5 p-10 justify-center items-center">
@@ -37,7 +37,7 @@ export default function FloatingMediaDetails({
           height={500}
           width={500 * ratio}
           quality={100}
-          className="object-contain md2:m-5 md2:w-1/2 bg-white"
+          className="object-contain md2:m-5 md2:w-1/2 bg-white select-none"
           onClick={(event) => event.stopPropagation()}
           onLoadingComplete={({ naturalWidth, naturalHeight }) =>
             setRatio(naturalWidth / naturalHeight)
@@ -46,7 +46,10 @@ export default function FloatingMediaDetails({
           blurDataURL={mediaDetails.source}
         ></Image>
 
-        <div className="hidden md2:block max-h-[90vh] rounded-sm p-1 sm:p-5 text-white break-word text-sm md:text-2xl overflow-auto space-y-10 transparent-scrollbar">
+        <div
+          className="hidden md2:block max-h-[90vh] rounded-sm p-1 sm:p-5 text-white break-word text-sm md:text-2xl overflow-auto space-y-10 transparent-scrollbar"
+          onClick={(event) => event.stopPropagation()}
+        >
           <h1 className="font-bold">{mediaDetails.title}</h1>
           <h2>{mediaDetails.description}</h2>
           <h3>{new Date(mediaDetails.uploadDate).toLocaleDateString()}</h3>

--- a/client/components/FloatingMediaDetails.tsx
+++ b/client/components/FloatingMediaDetails.tsx
@@ -37,7 +37,7 @@ export default function FloatingMediaDetails({
           height={500}
           width={500 * ratio}
           quality={100}
-          className="object-contain md2:m-5 md2:w-1/2 bg-white select-none"
+          className="object-contain md2:m-5 w-1/2 select-none"
           onClick={(event) => event.stopPropagation()}
           onLoadingComplete={({ naturalWidth, naturalHeight }) =>
             setRatio(naturalWidth / naturalHeight)
@@ -47,7 +47,7 @@ export default function FloatingMediaDetails({
         ></Image>
 
         <div
-          className="hidden md2:block max-h-[90vh] rounded-sm p-1 sm:p-5 text-white break-word text-sm md:text-2xl overflow-auto space-y-10 transparent-scrollbar"
+          className="block max-h-[90vh] rounded-sm p-1 sm:p-5 text-white break-word text-sm md:text-2xl overflow-auto space-y-10 transparent-scrollbar"
           onClick={(event) => event.stopPropagation()}
         >
           <h1 className="font-bold">{mediaDetails.title}</h1>


### PR DESCRIPTION
Instead of adding a go-to media page, the media details were just left on every screen size.